### PR TITLE
Fix issue 26#

### DIFF
--- a/src/backend/events/general.ts
+++ b/src/backend/events/general.ts
@@ -2,7 +2,6 @@ import { execSync } from 'child_process';
 import { Socket } from 'socket.io';
 import { checkIServerUp, closeProjectServers } from '../server';
 import {
-  activateProgram,
   getActiveProjectName,
   getProjectPath,
   getProjectsNameList,
@@ -136,15 +135,6 @@ export const generalEvents = (socket: Socket) => {
         success: false,
         currentRepoFolderPath,
       });
-    }
-  });
-
-  socket.on(EVENT_KEYS.ACTIVATE, async (arg) => {
-    try {
-      const success = await activateProgram(arg.activationKey);
-      emitSocketMessage(socket, EVENT_KEYS.ACTIVATE, { success });
-    } catch (error) {
-      emitSocketMessage(socket, EVENT_KEYS.ACTIVATE, { success: false });
     }
   });
 

--- a/src/renderer/components/devTools/devTools.tsx
+++ b/src/renderer/components/devTools/devTools.tsx
@@ -28,18 +28,18 @@ function DevTools({ onMinimize, onCenter, onMaximize, devToolsHeight }: Props) {
   const { resetLoggerState, serverLogs } = useLoggerStore();
   const [openConsoleDialog, setOpenConsoleDialog] = useState(false);
   const [search, setSearch] = useState('');
-  const serversLogsRef = useRef<{ clear: () => void } | null>(null)
+  const serversLogsRef = useRef<{ clear: () => void } | null>(null);
 
   const [selectedId, setSelectedId] = useState<TabIds>('console');
-  const showClear = [ 'console', 'serversLogs'].includes(selectedId);
-  const isConsole = 'console' === selectedId
+  const showClear = ['console', 'serversLogs'].includes(selectedId);
+  const isConsole = selectedId === 'console';
 
   const handleClear = () => {
     reportButtonClick(BUTTONS.CONSOLE_CLEAR);
-    if(selectedId === 'console'){
+    if (selectedId === 'console') {
       resetLoggerState();
-    }else if(selectedId === 'serversLogs' && serversLogsRef.current?.clear){
-      serversLogsRef.current.clear()
+    } else if (selectedId === 'serversLogs' && serversLogsRef.current?.clear) {
+      serversLogsRef.current.clear();
     }
   };
 
@@ -110,10 +110,12 @@ function DevTools({ onMinimize, onCenter, onMaximize, devToolsHeight }: Props) {
 
         <div
           style={
-            selectedId === 'serversLogs' ? { height: '100%' } : { display: 'none' }
+            selectedId === 'serversLogs'
+              ? { height: '100%' }
+              : { display: 'none' }
           }
         >
-          <ServersLogs ref={serversLogsRef}/>
+          <ServersLogs ref={serversLogsRef} />
         </div>
 
         {selectedId === 'console' && <Console search={search} />}

--- a/src/renderer/utils/electron.ts
+++ b/src/renderer/utils/electron.ts
@@ -2,10 +2,9 @@ import { EVENT_KEYS } from '../../types/events';
 import { reportSendEvent } from './analytics';
 import { handleReceiveEvent } from './events';
 
-export const isElectronEnabled = !!window.electron?.ipcRenderer
+export const isElectronEnabled = !!window.electron?.ipcRenderer;
 
 const sendMessage = (channel: EVENT_KEYS, ...args: any) => {
-
   if (!isElectronEnabled) {
     return;
   }
@@ -14,7 +13,6 @@ const sendMessage = (channel: EVENT_KEYS, ...args: any) => {
 };
 
 const on = (channel: EVENT_KEYS, func: (...args: any) => void) => {
-
   if (!isElectronEnabled) {
     return () => {};
   }
@@ -23,7 +21,6 @@ const on = (channel: EVENT_KEYS, func: (...args: any) => void) => {
     func(arg);
   });
 };
-
 
 export const ElectronEvents = {
   sendMessage,

--- a/src/renderer/utils/general.ts
+++ b/src/renderer/utils/general.ts
@@ -17,11 +17,7 @@ export const JSONStringifyExtra = (obj: any) =>
   });
 
 export const openInNewTab = (url: string) => {
-  const newWindow = window.open(
-    url,
-    '_blank',
-    'noopener,noreferrer',
-  );
+  const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
   if (newWindow) newWindow.opener = null;
 };
 

--- a/src/renderer/utils/socket.ts
+++ b/src/renderer/utils/socket.ts
@@ -4,9 +4,9 @@ import { reportSendEvent } from './analytics';
 import { isElectronEnabled } from './electron';
 import { flattenObject } from './general';
 
-const baseURl = window.location.href
+const baseURl = window.location.href;
 
-export const socket = io(isElectronEnabled?'http://localhost:1511':baseURl);
+export const socket = io(isElectronEnabled ? 'http://localhost:1511' : baseURl);
 
 export const emitSocketEvent = (
   event: EVENT_KEYS,


### PR DESCRIPTION
when adding a new route in Presets section, it was able to add already existing routes, also enabling to choose servers/parents that are already fully used. 

this fix,
disabling routes that already a response has chosen for them
disabling  parents that already are in full use (all of its routes in use)
disabling servers that already are in full use, (all of its parents in use)

