### PR TITLE
Correction of opening a project in the file manager - issue-24#

### DIFF
--- a/src/renderer/components/devTools/terminal/terminal.tsx
+++ b/src/renderer/components/devTools/terminal/terminal.tsx
@@ -143,7 +143,9 @@ export function CommandsTerminal() {
       handleCommands(args, print);
     },
     open: () => {
-      ElectronEvents.sendMessage(EVENT_KEYS.OPEN_PROJECT_DIRECTORY);
+      ElectronEvents.sendMessage(EVENT_KEYS.OPEN_PROJECT_DIRECTORY, {
+        platform: 'filemanager',
+      });
     },
     code: () => {
       ElectronEvents.sendMessage(EVENT_KEYS.OPEN_PROJECT_DIRECTORY, {


### PR DESCRIPTION
issue:
When trying to perform the "open" command in mockingbird terminal nothing happens


Correction:
 Sending platform = filemanager to cause the opening of the project root folder in file manager

(tested on mac only)