### PR TITLE
Add preset usage checks on deletion

### DIFF
--- a/src/backend/events/updateFiles.ts
+++ b/src/backend/events/updateFiles.ts
@@ -1,6 +1,8 @@
 import { Socket } from 'socket.io';
 import { SUPPORTED_PROJECT_DATA_VERSION } from '../../consts';
 import {
+  checkParentUsageInPresets,
+  checkServerUsageInPresets,
   createNewServer,
   deleteParent,
   deleteServer,
@@ -87,6 +89,26 @@ export const updateFilesEvents = (socket: Socket) => {
     }
   });
 
+  socket.on(EVENT_KEYS.CHECK_SERVER_PRESET_USAGE, async (arg) => {
+    try {
+      const { projectName, serverName } = arg;
+
+      const usedInPresets = await checkServerUsageInPresets(
+        projectName,
+        serverName,
+      );
+
+      socket.emit(EVENT_KEYS.CHECK_SERVER_PRESET_USAGE, {
+        success: true,
+        usedInPresets,
+        projectName,
+        serverName,
+      });
+    } catch (error) {
+      socket.emit(EVENT_KEYS.CHECK_SERVER_PRESET_USAGE, { success: false });
+    }
+  });
+
   socket.on(EVENT_KEYS.DELETE_SERVER, async (arg) => {
     try {
       const { projectName, serverName } = arg;
@@ -103,6 +125,28 @@ export const updateFilesEvents = (socket: Socket) => {
       });
     } catch (error) {
       socket.emit(EVENT_KEYS.DELETE_SERVER, { success: false });
+    }
+  });
+
+  socket.on(EVENT_KEYS.CHECK_PARENT_PRESET_USAGE, async (arg) => {
+    try {
+      const { projectName, serverName, parentId } = arg;
+
+      const usedInPresets = await checkParentUsageInPresets(
+        projectName,
+        serverName,
+        parentId,
+      );
+
+      socket.emit(EVENT_KEYS.CHECK_PARENT_PRESET_USAGE, {
+        success: true,
+        usedInPresets,
+        projectName,
+        serverName,
+        parentId,
+      });
+    } catch (error) {
+      socket.emit(EVENT_KEYS.CHECK_PARENT_PRESET_USAGE, { success: false });
     }
   });
 

--- a/src/backend/utils/files.ts
+++ b/src/backend/utils/files.ts
@@ -496,3 +496,64 @@ export async function isDirectoryEmpty(projectName: string): Promise<boolean> {
     return false; // or throw, depending on your error handling strategy
   }
 }
+
+export const checkParentUsageInPresets = async (
+  projectName: string,
+  serverName: string,
+  parentId: string,
+) => {
+  const presetFolders = await getProjectPresets(projectName);
+  const usedInPresets: { folderName: string; presetName: string }[] = [];
+
+  presetFolders.forEach((folder) => {
+    if (folder.presetsHash) {
+      Object.values(folder.presetsHash).forEach((preset) => {
+        if (preset.routesHash) {
+          const hasRouteInParent = Object.values(preset.routesHash).some(
+            (presetRoute) =>
+              presetRoute.serverId === serverName &&
+              presetRoute.parentId === parentId,
+          );
+
+          if (hasRouteInParent) {
+            usedInPresets.push({
+              folderName: folder.name,
+              presetName: preset.name,
+            });
+          }
+        }
+      });
+    }
+  });
+
+  return usedInPresets;
+};
+
+export const checkServerUsageInPresets = async (
+  projectName: string,
+  serverName: string,
+) => {
+  const presetFolders = await getProjectPresets(projectName);
+  const usedInPresets: { folderName: string; presetName: string }[] = [];
+
+  presetFolders.forEach((folder) => {
+    if (folder.presetsHash) {
+      Object.values(folder.presetsHash).forEach((preset) => {
+        if (preset.routesHash) {
+          const hasRouteInServer = Object.values(preset.routesHash).some(
+            (presetRoute) => presetRoute.serverId === serverName,
+          );
+
+          if (hasRouteInServer) {
+            usedInPresets.push({
+              folderName: folder.name,
+              presetName: preset.name,
+            });
+          }
+        }
+      });
+    }
+  });
+
+  return usedInPresets;
+};

--- a/src/consts/events.ts
+++ b/src/consts/events.ts
@@ -170,4 +170,12 @@ export const EVENTS_SNACKBAR: EventsSnackbarType = {
     success: null,
     fail: null,
   },
+  [EVENT_KEYS.CHECK_PARENT_PRESET_USAGE]: {
+    success: null,
+    fail: 'failed to check preset usage',
+  },
+  [EVENT_KEYS.CHECK_SERVER_PRESET_USAGE]: {
+    success: null,
+    fail: 'failed to check preset usage',
+  },
 };

--- a/src/renderer/components/details/graphqlRouteDetails/graphqlRouteDetails.tsx
+++ b/src/renderer/components/details/graphqlRouteDetails/graphqlRouteDetails.tsx
@@ -16,6 +16,10 @@ import {
   openInNewTab,
   reportButtonClick,
 } from '../../../utils';
+import {
+  findPresetsUsingRoute,
+  findPresetsUsingResponse,
+} from '../../../utils';
 import { useProjectStore } from '../../../state/project';
 import { useResponseActions, useRouteActions } from '../../../hooks/files';
 import { useSelectedGraphQlRoute } from '../../../hooks';
@@ -31,7 +35,7 @@ export function GraphqlRouteDetails() {
   const { route, parent, server } = useSelectedGraphQlRoute();
 
   const { setSelectedRoute, host, isServerUp } = useGeneralStore();
-  const { activeProjectName } = useProjectStore();
+  const { activeProjectName, presetFoldersHash } = useProjectStore();
   const [isCopied, setIsCopied] = useState(false);
   const [isRouteDialogOpen, setIsRouteDialogOpen] = useState(false);
   const [isDeleteRouteDialogOpen, setIsDeleteRouteDialogOpen] = useState(false);
@@ -40,6 +44,18 @@ export function GraphqlRouteDetails() {
   const [isResponseDialogOpen, setIsResponseDialogOpen] = useState(false);
   const [isDeleteResponseDialogOpen, setIsDeleteResponseDialogOpen] =
     useState(false);
+  const [routePresets, setRoutePresets] = useState<
+    {
+      folder: string;
+      preset: string;
+    }[]
+  >([]);
+  const [responsePresets, setResponsePresets] = useState<
+    {
+      folder: string;
+      preset: string;
+    }[]
+  >([]);
   const { deleteRoute } = useRouteActions();
   const { deleteResponse } = useResponseActions();
 
@@ -127,7 +143,13 @@ export function GraphqlRouteDetails() {
                 color="inherit"
                 onClick={() => {
                   reportButtonClick(BUTTONS.ROUTE_DETAILS_DELETE);
-
+                  const presets = findPresetsUsingRoute(
+                    presetFoldersHash,
+                    server?.name || '',
+                    parent?.id || '',
+                    route?.id || '',
+                  );
+                  setRoutePresets(presets);
                   setIsDeleteRouteDialogOpen(true);
                 }}
                 aria-label="close"
@@ -200,6 +222,14 @@ export function GraphqlRouteDetails() {
                 handleSetActive(route?.id || '', response.id);
               }}
               onDelete={() => {
+                const presets = findPresetsUsingResponse(
+                  presetFoldersHash,
+                  server?.name || '',
+                  parent?.id || '',
+                  route?.id || '',
+                  response.id,
+                );
+                setResponsePresets(presets);
                 setIsDeleteResponseDialogOpen(true);
                 setEditResponseData(response);
               }}
@@ -226,6 +256,7 @@ export function GraphqlRouteDetails() {
         <DeleteRouteDialog
           onClose={() => setIsDeleteRouteDialogOpen(false)}
           open={isDeleteRouteDialogOpen}
+          presets={routePresets}
           onConfirm={() => {
             deleteRoute(route, parent, server);
             setIsDeleteRouteDialogOpen(false);
@@ -240,6 +271,7 @@ export function GraphqlRouteDetails() {
           <DeleteResponseDialog
             onClose={() => setIsDeleteResponseDialogOpen(false)}
             open={isDeleteResponseDialogOpen}
+            presets={responsePresets}
             onConfirm={() => {
               deleteResponse(server, parent, route, editResponseData);
               setIsDeleteResponseDialogOpen(false);

--- a/src/renderer/components/details/graphqlRouteDetails/graphqlRouteDetails.tsx
+++ b/src/renderer/components/details/graphqlRouteDetails/graphqlRouteDetails.tsx
@@ -15,8 +15,6 @@ import {
   getGraphqlRouteBGColor,
   openInNewTab,
   reportButtonClick,
-} from '../../../utils';
-import {
   findPresetsUsingRoute,
   findPresetsUsingResponse,
 } from '../../../utils';

--- a/src/renderer/components/details/routeDetails/routeDetails.tsx
+++ b/src/renderer/components/details/routeDetails/routeDetails.tsx
@@ -16,6 +16,8 @@ import {
   getRouteBGColor,
   openInNewTab,
   reportButtonClick,
+  findPresetsUsingRoute,
+  findPresetsUsingResponse,
 } from '../../../utils';
 import { useProjectStore } from '../../../state/project';
 import { useResponseActions, useRouteActions } from '../../../hooks/files';
@@ -28,10 +30,6 @@ import {
 } from '../../dialogs';
 import { EVENT_KEYS } from '../../../../types/events';
 import { BUTTONS } from '../../../../consts/analytics';
-import {
-  findPresetsUsingRoute,
-  findPresetsUsingResponse,
-} from '../../../utils';
 
 export function RouteDetails() {
   const { route, parent, server } = useSelectedRestRoute();

--- a/src/renderer/components/details/routeDetails/routeDetails.tsx
+++ b/src/renderer/components/details/routeDetails/routeDetails.tsx
@@ -28,12 +28,16 @@ import {
 } from '../../dialogs';
 import { EVENT_KEYS } from '../../../../types/events';
 import { BUTTONS } from '../../../../consts/analytics';
+import {
+  findPresetsUsingRoute,
+  findPresetsUsingResponse,
+} from '../../../utils';
 
 export function RouteDetails() {
   const { route, parent, server } = useSelectedRestRoute();
 
   const { setSelectedRoute, host, isServerUp } = useGeneralStore();
-  const { activeProjectName } = useProjectStore();
+  const { activeProjectName, presetFoldersHash } = useProjectStore();
   const [editRouteData, setEditRouteData] = useState<Route | null>(null);
   const [isRouteDialogOpen, setIsRouteDialogOpen] = useState(false);
   const [isDeleteRouteDialogOpen, setIsDeleteRouteDialogOpen] = useState(false);
@@ -42,6 +46,18 @@ export function RouteDetails() {
   const [isResponseDialogOpen, setIsResponseDialogOpen] = useState(false);
   const [isDeleteResponseDialogOpen, setIsDeleteResponseDialogOpen] =
     useState(false);
+  const [routePresets, setRoutePresets] = useState<
+    {
+      folder: string;
+      preset: string;
+    }[]
+  >([]);
+  const [responsePresets, setResponsePresets] = useState<
+    {
+      folder: string;
+      preset: string;
+    }[]
+  >([]);
   const { deleteRoute } = useRouteActions();
   const { deleteResponse } = useResponseActions();
 
@@ -143,7 +159,13 @@ export function RouteDetails() {
                 color="inherit"
                 onClick={() => {
                   reportButtonClick(BUTTONS.ROUTE_DETAILS_DELETE);
-
+                  const presets = findPresetsUsingRoute(
+                    presetFoldersHash,
+                    server?.name || '',
+                    parent?.id || '',
+                    route?.id || '',
+                  );
+                  setRoutePresets(presets);
                   setIsDeleteRouteDialogOpen(true);
                 }}
                 aria-label="close"
@@ -186,6 +208,14 @@ export function RouteDetails() {
                 handleSetActive(route?.id || '', response.id);
               }}
               onDelete={() => {
+                const presets = findPresetsUsingResponse(
+                  presetFoldersHash,
+                  server?.name || '',
+                  parent?.id || '',
+                  route?.id || '',
+                  response.id,
+                );
+                setResponsePresets(presets);
                 setIsDeleteResponseDialogOpen(true);
                 setEditResponseData(response);
               }}
@@ -212,6 +242,7 @@ export function RouteDetails() {
         <DeleteRouteDialog
           onClose={() => setIsDeleteRouteDialogOpen(false)}
           open={isDeleteRouteDialogOpen}
+          presets={routePresets}
           onConfirm={() => {
             deleteRoute(route, parent, server);
             setIsDeleteRouteDialogOpen(false);
@@ -226,6 +257,7 @@ export function RouteDetails() {
           <DeleteResponseDialog
             onClose={() => setIsDeleteResponseDialogOpen(false)}
             open={isDeleteResponseDialogOpen}
+            presets={responsePresets}
             onConfirm={() => {
               deleteResponse(server, parent, route, editResponseData);
               setIsDeleteResponseDialogOpen(false);

--- a/src/renderer/components/dialogs/deleteResponseDialog/deleteResponseDialog.tsx
+++ b/src/renderer/components/dialogs/deleteResponseDialog/deleteResponseDialog.tsx
@@ -13,10 +13,12 @@ export function DeleteResponseDialog({
   open,
   onClose,
   onConfirm,
+  presets,
 }: {
   open: boolean;
   onClose: () => void;
   onConfirm: () => void;
+  presets?: { folder: string; preset: string }[];
 }) {
   const handleDelete = () => {
     reportButtonClick(BUTTONS.DELETE_RESPONSE_DIALOG_DELETE);
@@ -38,6 +40,20 @@ export function DeleteResponseDialog({
     >
       <DialogTitle id="alert-dialog-title">delete response</DialogTitle>
       <DialogContent>
+        {presets && presets.length > 0 && (
+          <>
+            <DialogContentText>
+              this response is used in the following presets:
+            </DialogContentText>
+            <ul>
+              {presets.map((p) => (
+                <li
+                  key={`${p.folder}-${p.preset}`}
+                >{`${p.folder} / ${p.preset}`}</li>
+              ))}
+            </ul>
+          </>
+        )}
         <DialogContentText id="alert-dialog-description">
           are you sure you want to delete this response?
         </DialogContentText>

--- a/src/renderer/components/dialogs/deleteResponseDialog/deleteResponseDialog.tsx
+++ b/src/renderer/components/dialogs/deleteResponseDialog/deleteResponseDialog.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import { BUTTONS } from '../../../../consts/analytics';
 import { reportButtonClick } from '../../../utils';
+import { PresetUsageWarning } from '../../presetUsageWarning';
 
 export function DeleteResponseDialog({
   open,
@@ -40,26 +41,17 @@ export function DeleteResponseDialog({
     >
       <DialogTitle id="alert-dialog-title">delete response</DialogTitle>
       <DialogContent>
-        {presets && presets.length > 0 && (
-          <>
-            <DialogContentText>
-              this response is used in the following presets:
-            </DialogContentText>
-            <ul>
-              {presets.map((p) => (
-                <li
-                  key={`${p.folder}-${p.preset}`}
-                >{`${p.folder} / ${p.preset}`}</li>
-              ))}
-            </ul>
-          </>
-        )}
         <DialogContentText id="alert-dialog-description">
           are you sure you want to delete this response?
         </DialogContentText>
         <DialogContentText id="alert-dialog-description">
           this will permanently delete the response and its data
         </DialogContentText>
+
+        <PresetUsageWarning
+          usedInPresets={presets || []}
+          entityType="response"
+        />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} autoFocus>

--- a/src/renderer/components/dialogs/deleteRouteDialog/deleteRouteDialog.tsx
+++ b/src/renderer/components/dialogs/deleteRouteDialog/deleteRouteDialog.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import { BUTTONS } from '../../../../consts/analytics';
 import { reportButtonClick } from '../../../utils';
+import { PresetUsageWarning } from '../../presetUsageWarning';
 
 export function DeleteRouteDialog({
   open,
@@ -40,26 +41,14 @@ export function DeleteRouteDialog({
     >
       <DialogTitle id="alert-dialog-title">delete route</DialogTitle>
       <DialogContent>
-        {presets && presets.length > 0 && (
-          <>
-            <DialogContentText>
-              this route is used in the following presets:
-            </DialogContentText>
-            <ul>
-              {presets.map((p) => (
-                <li
-                  key={`${p.folder}-${p.preset}`}
-                >{`${p.folder} / ${p.preset}`}</li>
-              ))}
-            </ul>
-          </>
-        )}
         <DialogContentText id="alert-dialog-description">
           are you sure you want to delete this route?
         </DialogContentText>
         <DialogContentText id="alert-dialog-description">
           this will permanently delete the route and all its responses
         </DialogContentText>
+
+        <PresetUsageWarning usedInPresets={presets || []} entityType="route" />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} autoFocus>

--- a/src/renderer/components/dialogs/deleteRouteDialog/deleteRouteDialog.tsx
+++ b/src/renderer/components/dialogs/deleteRouteDialog/deleteRouteDialog.tsx
@@ -13,10 +13,12 @@ export function DeleteRouteDialog({
   open,
   onClose,
   onConfirm,
+  presets,
 }: {
   open: boolean;
   onClose: () => void;
   onConfirm: () => void;
+  presets?: { folder: string; preset: string }[];
 }) {
   const handleDelete = () => {
     reportButtonClick(BUTTONS.DELETE_ROUTE_DIALOG_DELETE);
@@ -38,6 +40,20 @@ export function DeleteRouteDialog({
     >
       <DialogTitle id="alert-dialog-title">delete route</DialogTitle>
       <DialogContent>
+        {presets && presets.length > 0 && (
+          <>
+            <DialogContentText>
+              this route is used in the following presets:
+            </DialogContentText>
+            <ul>
+              {presets.map((p) => (
+                <li
+                  key={`${p.folder}-${p.preset}`}
+                >{`${p.folder} / ${p.preset}`}</li>
+              ))}
+            </ul>
+          </>
+        )}
         <DialogContentText id="alert-dialog-description">
           are you sure you want to delete this route?
         </DialogContentText>

--- a/src/renderer/components/index.ts
+++ b/src/renderer/components/index.ts
@@ -8,5 +8,6 @@ export * from './dialogs';
 export * from './errorBoundary';
 export * from './globalEvents';
 export * from './logRow';
+export * from './presetUsageWarning';
 export * from './projectDataUnsupported';
 export * from './tabs';

--- a/src/renderer/components/presetUsageWarning/index.ts
+++ b/src/renderer/components/presetUsageWarning/index.ts
@@ -1,0 +1,1 @@
+export * from './presetUsageWarning';

--- a/src/renderer/components/presetUsageWarning/presetUsageWarning.tsx
+++ b/src/renderer/components/presetUsageWarning/presetUsageWarning.tsx
@@ -1,0 +1,160 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import LaunchIcon from '@mui/icons-material/Launch';
+import { useGeneralStore } from '../../state/general';
+import { useProjectStore } from '../../state/project';
+
+type PresetInfo =
+  | { folderName: string; presetName: string }
+  | { folder: string; preset: string };
+
+interface PresetUsageWarningProps {
+  isChecking?: boolean;
+  usedInPresets: PresetInfo[];
+  entityType: 'parent' | 'server' | 'route' | 'response';
+}
+
+export function PresetUsageWarning({
+  isChecking = false,
+  usedInPresets,
+  entityType,
+}: PresetUsageWarningProps) {
+  const { setSelectedPreset, setSelectedTab } = useGeneralStore();
+  const { presetFoldersHash } = useProjectStore();
+
+  if (isChecking) {
+    return (
+      <Typography variant="body2" color="textSecondary" sx={{ mt: 2 }}>
+        Checking preset usage...
+      </Typography>
+    );
+  }
+
+  if (usedInPresets.length === 0) {
+    return null;
+  }
+
+  // Normalize the preset data to handle both formats
+  const normalizedPresets = usedInPresets.map((preset) => {
+    if ('folderName' in preset) {
+      return { folderName: preset.folderName, presetName: preset.presetName };
+    }
+    return { folderName: preset.folder, presetName: preset.preset };
+  });
+
+  const handlePresetClick = (folderName: string, presetName: string) => {
+    // Find the folder ID by name
+    const folder = Object.values(presetFoldersHash || {}).find(
+      (f) => f.name === folderName,
+    );
+
+    if (!folder) return;
+
+    // Find the preset ID by name within the folder
+    const preset = Object.values(folder.presetsHash || {}).find(
+      (p) => p.name === presetName,
+    );
+
+    if (!preset) return;
+
+    // Navigate to the preset
+    setSelectedTab('presets');
+    setSelectedPreset({
+      folderId: folder.id,
+      presetId: preset.id,
+    });
+  };
+
+  const getWarningMessage = () => {
+    switch (entityType) {
+      case 'route':
+        return 'This route is used in the following presets:';
+      case 'response':
+        return 'This response is used in the following presets:';
+      case 'parent':
+      case 'server':
+        return `This ${entityType} contains routes that are used in the following presets:`;
+      default:
+        return 'This item is used in the following presets:';
+    }
+  };
+
+  const getConsequenceMessage = () => {
+    switch (entityType) {
+      case 'route':
+        return 'Deleting this route will make these presets unusable for this specific route.';
+      case 'response':
+        return 'Deleting this response will affect these presets that rely on this specific response.';
+      case 'parent':
+      case 'server':
+        return `Deleting this ${entityType} will make these presets unusable for the affected routes.`;
+      default:
+        return 'Deleting this item will affect these presets.';
+    }
+  };
+
+  return (
+    <Alert severity="warning" sx={{ mt: 2 }}>
+      <Typography variant="subtitle2" gutterBottom>
+        ⚠️ Warning: {getWarningMessage()}
+      </Typography>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="preset-usage-content"
+          id="preset-usage-header"
+        >
+          <Typography variant="body2">
+            View {normalizedPresets.length} affected preset
+            {normalizedPresets.length > 1 ? 's' : ''}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <List dense>
+            {normalizedPresets.map((preset) => (
+              <ListItem
+                key={preset.folderName + preset.presetName}
+                disablePadding
+              >
+                <ListItemButton
+                  onClick={() =>
+                    handlePresetClick(preset.folderName, preset.presetName)
+                  }
+                  sx={{
+                    borderRadius: 1,
+                    cursor: 'pointer',
+                    '&:hover': {
+                      backgroundColor: 'action.hover',
+                    },
+                  }}
+                >
+                  <ListItemText
+                    primary={preset.presetName}
+                    secondary={`Folder: ${preset.folderName} • Click to navigate`}
+                  />
+                  <ListItemIcon sx={{ minWidth: 'auto', ml: 1 }}>
+                    <LaunchIcon fontSize="small" color="action" />
+                  </ListItemIcon>
+                </ListItemButton>
+              </ListItem>
+            ))}
+          </List>
+        </AccordionDetails>
+      </Accordion>
+      <Typography variant="body2" sx={{ mt: 1 }}>
+        {getConsequenceMessage()}
+      </Typography>
+    </Alert>
+  );
+}

--- a/src/renderer/utils/general.ts
+++ b/src/renderer/utils/general.ts
@@ -6,6 +6,7 @@ import {
   Preset,
   PresetRoute,
   ServersHash,
+  PresetsFolderHash,
 } from '../../types';
 
 export const JSONStringifyExtra = (obj: any) =>
@@ -401,3 +402,55 @@ export const flattenObject = (
     }
     return result;
   }, {});
+
+export const findPresetsUsingRoute = (
+  presetFoldersHash: PresetsFolderHash,
+  serverId: string,
+  parentId: string,
+  routeId: string,
+) => {
+  const presets: { folder: string; preset: string }[] = [];
+  Object.values(presetFoldersHash || {}).forEach((folder) => {
+    Object.values(folder.presetsHash || {}).forEach((preset) => {
+      const routes = Object.values(preset.routesHash || {});
+      if (
+        routes.some(
+          (r) =>
+            r.serverId === serverId &&
+            r.parentId === parentId &&
+            r.routeId === routeId,
+        )
+      ) {
+        presets.push({ folder: folder.name, preset: preset.name });
+      }
+    });
+  });
+  return presets;
+};
+
+export const findPresetsUsingResponse = (
+  presetFoldersHash: PresetsFolderHash,
+  serverId: string,
+  parentId: string,
+  routeId: string,
+  responseId: string,
+) => {
+  const presets: { folder: string; preset: string }[] = [];
+  Object.values(presetFoldersHash || {}).forEach((folder) => {
+    Object.values(folder.presetsHash || {}).forEach((preset) => {
+      const routes = Object.values(preset.routesHash || {});
+      if (
+        routes.some(
+          (r) =>
+            r.serverId === serverId &&
+            r.parentId === parentId &&
+            r.routeId === routeId &&
+            r.responseId === responseId,
+        )
+      ) {
+        presets.push({ folder: folder.name, preset: preset.name });
+      }
+    });
+  });
+  return presets;
+};

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -16,6 +16,8 @@ export enum EVENT_KEYS {
   PROJECT_DATA_IS_UNSUPPORTED = 'projectDataIsUnsupported',
   DELETE_SERVER = 'deleteServer',
   DELETE_PARENT = 'deleteParent',
+  CHECK_PARENT_PRESET_USAGE = 'checkParentPresetUsage',
+  CHECK_SERVER_PRESET_USAGE = 'checkServerPresetUsage',
   BRANCH_LIST = 'branchList',
   PROJECT_DATA = 'projectData',
   CHECKOUT_TO_BRANCH = 'checkoutToBranch',


### PR DESCRIPTION
## Summary
- warn if deleting a route or response that is used in presets
- show preset names in the delete confirmation dialogs

## Testing
- `npm run lint` *(fails: prettier errors)*
- `npm test` *(fails: main process not built)*

------
https://chatgpt.com/codex/tasks/task_e_685da27078e8832aa302552e0084f634